### PR TITLE
修改vtable的翻译

### DIFF
--- a/rust-glossary.md
+++ b/rust-glossary.md
@@ -353,7 +353,7 @@ variable capture                 | 变量捕获                      |
 variant                          | 变量                          |
 vector                           | （动态数组，一般不译）        | vector 本义是“向量”
 visibility                       | 可见性                        |
-vtable                           | 虚函数表                      |
+vtable                           | 虚表                          |
 **W**                            |                               |
 where clause                     | where 子句，where 从句，where 分句 | 在数据库的官方手册中多翻译成“子句”，英语语法中翻译成“从句”
 wrap                             | 包裹                          | 暂译！


### PR DESCRIPTION
虽然在很多正规文献中将“vtable”作为virtual method table的简写，因而译作虚拟函数表，但我建议将其译为“虚表”更好，一来这更符合英文简写的形式本身，二来并没有任何人规定虚表只能存函数指针。

比如有人[提过可以给trait里加field](https://github.com/rust-lang/rfcs/pull/1546)，这个如果未来有一天要多态实现，那么对应的指针很可能也会放入虚表。