### PR TITLE
翻译trait为“特质”

### DIFF
--- a/rust-glossary.md
+++ b/rust-glossary.md
@@ -344,7 +344,7 @@ the most significant bit (MSB)   | 最高数字位                    |
 thread                           | 线程                          |
 TOML                             | （不译）                      | Tom's Obvious, Minimal Language <br>的缩写，一种配置语言
 token tree                       | 令牌树？                      | 待进一步斟酌
-trait                            | 特质                        |
+trait                            | 特质                        | 其字面上有“特性，特征”之意
 trait bound                      | 特质约束                    | bound 有“约束，限制，限定”之意
 trait object                     | 特质对象                    |
 transmute                        | （不译）                      | 其字面上有“变化，变形，变异”之意，<br>不作翻译

--- a/rust-glossary.md
+++ b/rust-glossary.md
@@ -110,7 +110,7 @@ documentation                    | 文档                          |
 dot operator                     | 点运算符                      |
 DST                              | 动态大小类型                  | dynamic sized type，一般不译，<br>使用英文缩写形式
 dynamic language                 | 动态类型语言                  |
-dynamic trait type               | 动态 trait 类型               |
+dynamic trait type               | 动态特征类型               |
 **E**                            |                               |
 encapsulation                    | 封装                          |
 equality test                    | 相等测试                      |
@@ -155,7 +155,7 @@ hash map                         | 散列映射，哈希表              |
 heap                             | 堆                            |
 hierarchy                        | 层次，分层，层次结构          |
 higher rank lifetime             | 高阶生命周期                  |
-higher rank trait bound          | 高阶 trait 约束               |
+higher rank trait bound          | 高阶特征约束               |
 higher tank type                 | 高阶类型                      |
 hygiene                          | 卫生                          |
 hygienic macro system            | 卫生宏系统                    |
@@ -344,9 +344,9 @@ the most significant bit (MSB)   | 最高数字位                    |
 thread                           | 线程                          |
 TOML                             | （不译）                      | Tom's Obvious, Minimal Language <br>的缩写，一种配置语言
 token tree                       | 令牌树？                      | 待进一步斟酌
-trait                            | （不译）                      | 其字面上有“特性，特征”之意，不作翻译
-trait bound                      | trait 约束                    | bound 有“约束，限制，限定”之意
-trait object                     | trait 对象                    |
+trait                            | 特征                        |
+trait bound                      | 特征约束                    | bound 有“约束，限制，限定”之意
+trait object                     | 特征对象                    |
 transmute                        | （不译）                      | 其字面上有“变化，变形，变异”之意，<br>不作翻译
 trivial                          | 平凡的                        |
 troubleshooting                  | 疑难解答，故障诊断，<br>故障排除，故障分析 |

--- a/rust-glossary.md
+++ b/rust-glossary.md
@@ -110,7 +110,7 @@ documentation                    | 文档                          |
 dot operator                     | 点运算符                      |
 DST                              | 动态大小类型                  | dynamic sized type，一般不译，<br>使用英文缩写形式
 dynamic language                 | 动态类型语言                  |
-dynamic trait type               | 动态特征类型               |
+dynamic trait type               | 动态特质类型               |
 **E**                            |                               |
 encapsulation                    | 封装                          |
 equality test                    | 相等测试                      |
@@ -155,7 +155,7 @@ hash map                         | 散列映射，哈希表              |
 heap                             | 堆                            |
 hierarchy                        | 层次，分层，层次结构          |
 higher rank lifetime             | 高阶生命周期                  |
-higher rank trait bound          | 高阶特征约束               |
+higher rank trait bound          | 高阶特质约束               |
 higher tank type                 | 高阶类型                      |
 hygiene                          | 卫生                          |
 hygienic macro system            | 卫生宏系统                    |
@@ -344,9 +344,9 @@ the most significant bit (MSB)   | 最高数字位                    |
 thread                           | 线程                          |
 TOML                             | （不译）                      | Tom's Obvious, Minimal Language <br>的缩写，一种配置语言
 token tree                       | 令牌树？                      | 待进一步斟酌
-trait                            | 特征                        |
-trait bound                      | 特征约束                    | bound 有“约束，限制，限定”之意
-trait object                     | 特征对象                    |
+trait                            | 特质                        |
+trait bound                      | 特质约束                    | bound 有“约束，限制，限定”之意
+trait object                     | 特质对象                    |
 transmute                        | （不译）                      | 其字面上有“变化，变形，变异”之意，<br>不作翻译
 trivial                          | 平凡的                        |
 troubleshooting                  | 疑难解答，故障诊断，<br>故障排除，故障分析 |


### PR DESCRIPTION
在Rust的常用概念中，大多数名词都有相应的中文翻译，而“trait”作为一个其他语言里较少出现的概念，目前没有公认的翻译。我感觉到为了更好的一致性，应该考虑为这个概念也拣选一个翻译。

根据[cnki](http://dict.cnki.net/)的资料，“trait”在学术上的几个常见翻译包括“性状”、“特质”、“特点”、“特征”、“特性”，其中“特性”一词有时会与“feature”相混淆，而“特点”一词的应用较为宽泛，常被用于描述一般性的特点而非一个学术性的概念，因而这两个词可能不太合适。

为了研究剩下几个词，可以考虑摘取一些例句来进行对比（主要取自TRPL的10.2、17.2和19.2）：

英文 | 性状 | 特质 | 特征
-------|--------|-------|-------
implement a trait on a type | 在一个类型上实现一个性状 | 在一个类型上实现一个特质 | 在一个类型上实现一个特征
bring the trait into their scope | 将这个性状引入它们的作用域 | 将这个特质引入它们的作用域 | 将这个特征引入它们的作用域
create a trait object | 创建一个性状对象 | 创建一个特质对象 | 创建一个特征对象
define the `Iterator` trait | 定义 `Iterator` 性状 | 定义 `Iterator` 特质 | 定义 `Iterator` 特征
when a trait has a generic parameter | 当一个性状有泛型参数时 | 当一个特质有泛型参数时 | 当一个特征有泛型参数时
making it easier to use the trait | 让使用这个性状更容易 | 让使用这个特质更容易 | 让使用这个特征更容易
specifying the trait name | 指定性状名 | 指定特质名 | 指定特征名
adding a trait bound to the trait | 为这个性状增加一个性状约束 | 为这个特质增加一个特质约束 | 为这个特征增加一个特征约束
a supertrait of the trait | 这个性状的一个超性状 | 这个特质的一个超特质 | 这个特征的一个超特征

我感觉“特征”在大多数语境下读起来更顺，也不容易产生什么歧义，其次是“性状”。在所有这些上下文中，只有“超特征”这个表达看起来比较奇怪。“性状”似乎与生物的关系过于紧密，感觉不少情况下都有一点违和。

鉴于此我提议将“trait”翻译为“特征”，大家觉得如何？

# 前例

C++里也有“trait”一词，目前已知的翻译有：
* [cppreference](https://zh.cppreference.com/w/cpp/types#.E7.B1.BB.E5.9E.8B.E7.89.B9.E6.80.A7.28C.2B.2B11_.E8.B5.B7.29)上将其翻译为“特性”
* [微软](https://docs.microsoft.com/zh-cn/cpp/standard-library/type-traits?view=vs-2019)将其翻译为“特征”

另据 @ZhangHanDong 所说，在中国的一些Rust资料里已经将其译为“特质”。如果这种译法已有共识并被广泛采纳，可以考虑使用。