### PR TITLE
Update URL to Rust reference in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Rust 语言相关术语中英文对照表，词汇来源:
 欢迎提供更多的翻译参考来源 :-)
 
 [rust-book]:https://doc.rust-lang.org/book/
-[reference]:https://doc.rust-lang.org/reference.html
+[reference]:https://doc.rust-lang.org/reference/
 [rust-std]:https://doc.rust-lang.org/std/
 [rustonomicon]:https://doc.rust-lang.org/nomicon/
 [rust-by-example]:http://rustbyexample.com/


### PR DESCRIPTION
https://doc.rust-lang.org/reference.html 现在的内容是:
> The Rust Reference has moved
>We’ve split up the reference into chapters. Please find it at its new home here.