### PR TITLE
悬垂指针 -> 悬空指针

### DIFF
--- a/rust-glossary.md
+++ b/rust-glossary.md
@@ -87,7 +87,7 @@ curly braces                     | 大括号，包含“{”和“}”          
 custom type                      | 自定义类型                    |
 Coherence                        |    连贯性                   | 理由是：实际上这个 Coherence 这个词在其相关 [RFC 2451](https://rust-lang.github.io/rfcs/2451-re-rebalancing-coherence.html) 中上下文语境中的意思是，让编译器推理特质更加流畅更加连贯，不要出错。所以“连贯性”更符合这个词在 Rust 中的本意。|
 **D**                            |                               |
-dangling pointer                 | 悬垂指针                      | use after free 在释放后使用
+dangling pointer                 | 悬空指针                      | use after free 在释放后使用
 data race                        | 数据竞争                      |
 dead code                        | 死代码，无效代码，不可达代码  |
 deallocate                       | 释放，重新分配                |


### PR DESCRIPTION
参考 https://zh.wikipedia.org/wiki/%E8%BF%B7%E9%80%94%E6%8C%87%E9%92%88 ：
> 在[计算机编程](https://zh.wikipedia.org/wiki/%E8%AE%A1%E7%AE%97%E6%9C%BA%E7%BC%96%E7%A8%8B)领域中，迷途指针，或称**悬空指针**、野指针，指的是不指向任何合法的对象的[指针](https://zh.wikipedia.org/wiki/%E6%8C%87%E9%92%88_(%E4%BF%A1%E6%81%AF%E5%AD%A6))。